### PR TITLE
Add MeterCall (zapier-killer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,5 @@ A curated list of awesome SaaS (Software as a server) starter.
 ## User Experience
 
 - [UserTesting](https://www.usertesting.com/) - Hear what your audience is saying and see what they mean. So you can create better experiences.
+
+- [MeterCall](https://metercall.ai/?v=c&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** Zapier has 7,000 apps. MeterCall has 21,000,000 APIs. One bill. Metered by the call.
- **URL:** https://metercall.ai/?v=c&src=github
- **Why it belongs here:** A curated list for SaaS (Software as a services)

Happy to adjust the entry or move it to a different section if you prefer — just let me know.