### PR TITLE
Add igly.ai to Product & Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 ## Product & Design
 
 - [Figma](https://www.figma.com/) - the collaborative interface design tool.
+- [igly.ai](https://igly.ai/) - AI-powered image editing for background removal, generative fill, upscaling, and product photo editing.
 - [Zeplin](https://zeplin.io/) - Handoff designs and styleguides with accurate specs, assets, code snippets—automatically.
 - [Whimsical](https://whimsical.com/) - Unified suite of collaboration tools. Great for product specs, wikis, brainstorming, ideation, user flows, architecture diagrams and more.
 - [Lanhu](https://lanhuapp.com/web/#/item) - Efficient product design collaboration platform.


### PR DESCRIPTION
Adds [igly.ai](https://igly.ai/) to the Product & Design section.

igly.ai is an AI-powered image editing SaaS for background removal, generative fill/inpainting, image upscaling, and product photo editing.

Demo: https://www.youtube.com/watch?v=HB2E1WZ12is

Closes #21.
