### PR TITLE
Add DishRoll — AI meal planning SaaS (closes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [Lobe](https://lobe.ai/) - Helps you train machine learning models with a free, easy to use tool.
 - [wombo.art](https://app.wombo.art/) - Create amazing works of art in seconds with the power of AI.
 - [Vedika](https://vedika.io/) - AI-powered Vedic astrology API with 6-agent swarm intelligence for natural language predictions.
+- - [DishRoll](https://dishroll.netlify.app/) - AI-powered meal planning SaaS: generates personalised weekly meal plans, recipe libraries, and shopping lists. Freemium model via Stripe.
 
 ## VR
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [Lobe](https://lobe.ai/) - Helps you train machine learning models with a free, easy to use tool.
 - [wombo.art](https://app.wombo.art/) - Create amazing works of art in seconds with the power of AI.
 - [Vedika](https://vedika.io/) - AI-powered Vedic astrology API with 6-agent swarm intelligence for natural language predictions.
-- - [DishRoll](https://dishroll.netlify.app/) - AI-powered meal planning SaaS: generates personalised weekly meal plans, recipe libraries, and shopping lists. Freemium model via Stripe.
+- [DishRoll](https://dishroll.netlify.app/) - AI-powered meal planning SaaS: generates personalised weekly meal plans, recipe libraries, and shopping lists. Freemium model via Stripe.
 
 ## VR
 


### PR DESCRIPTION
Adds DishRoll to the AI section as requested in issue #16.

**Entry:**
- [DishRoll](https://dishroll.netlify.app/) - AI-powered meal planning SaaS: generates personalised weekly meal plans, recipe libraries, and shopping lists. Freemium model via Stripe.
Addressed feedback from maintainer:
- Compressed description to 1-2 sentences (no feature bullet lists)
- - Clean single-level markdown list formatting
- - Placed in the AI section alongside similar tools