### PR TITLE
Add findmemail.io under Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [SocialGrep Reddit Alerts](https://socialgrep.com/alerts) - social media listening tool. "Signals out of the social web of noise".
 - [SquareSpace](https://www.squarespace.com/) - Website Builder — Create a Website in Minutes.
 - [EditorX](https://editorx.com/) - Editor X is an advanced creation platform for designers and web professionals. The platform combines cutting edge responsive design with smooth drag and drop.
-- [PagesRUs](https://pagesrus.com) - AI-powered B2B business discovery and lead generation platform to find companies, suppliers, distributors, and buyers by niche and location.
+- [findmemail.io](https://findmemail.io) - B2B email finder with plain-English ICP search and SMTP-verified founder/decision-maker emails. Free tier (50 credits) and $200 lifetime tier.- [PagesRUs](https://pagesrus.com) - AI-powered B2B business discovery and lead generation platform to find companies, suppliers, distributors, and buyers by niche and location.
 
 
 ## Low & No Code Platform


### PR DESCRIPTION
Adds findmemail.io to **Marketing** section, alongside the existing PagesRUs entry.

- B2B email finder with plain-English ICP search (e.g. "Series A SaaS founders in NYC")
- Each email SMTP-verified at request time (RCPT TO probe), not pattern-matched
- 32k+ companies indexed; founder/decision-maker emails
- Free tier: 50 credits, no card
- $200 lifetime tier — fits indie founder budgets

Follows the existing `- [Tool](url) - description.` format.