### PR TITLE
Add SalesLabel to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [SquareSpace](https://www.squarespace.com/) - Website Builder — Create a Website in Minutes.
 - [EditorX](https://editorx.com/) - Editor X is an advanced creation platform for designers and web professionals. The platform combines cutting edge responsive design with smooth drag and drop.
 - [PagesRUs](https://pagesrus.com) - AI-powered B2B business discovery and lead generation platform to find companies, suppliers, distributors, and buyers by niche and location.
+- [SalesLabel](https://sales-label.com) - White-label outbound sales infrastructure platform for B2B agencies. Helps 100+ agencies launch reseller offers under their own brand.
 
 
 ## Low & No Code Platform


### PR DESCRIPTION
Hi @georgezouq, thanks for maintaining this list — it's been useful as I've explored the SaaS space.

Proposing **SalesLabel** for the *Marketing* section — a white-label outbound sales infrastructure platform for B2B agencies. It helps 100+ agencies launch their own outbound offers under their own brand, with average results of 42% reply rates and $180K in pipeline per agency client.

We've also published a free, open margin calculator that other agency operators may find useful: https://sales-label.com/tools/margin-calculator

Single line added to the Marketing section:

```
- [SalesLabel](https://sales-label.com) - White-label outbound sales infrastructure platform for B2B agencies. Helps 100+ agencies launch reseller offers under their own brand.
```

Happy to revise wording, length, or placement. Thanks for considering!