### PR TITLE
Add LinkyPO to CMS & Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 
 - [Webflow](https://webflow.com/) - Empowers designers to build professional, custom websites in a completely visual canvas.
 - [Linkz.ai](https://linkz.ai) - Immersive hyperlink previews to keep visitors on your website‎
+- [LinkyPO](https://linkypo.com) - Free link-in-bio + mini-site builder with 21 block types (calendar booking, lead forms, OCR lists, loyalty stamps), Google/Outlook calendar sync and an AI SEO coach.
 
 ## Log Analysis
 


### PR DESCRIPTION
Adds LinkyPO to the **CMS & Website** section, alongside Webflow and Linkz.ai.

**Tool:** [LinkyPO](https://linkypo.com) — Free link-in-bio + mini-site builder with 21 block types (calendar booking, lead forms, OCR lists, loyalty stamps), Google Calendar / Outlook sync and an AI SEO coach.

**Why it fits this list:**
- Live SaaS product (Spanish + English), free tier without credit card
- Same category as Webflow already on the list
- Targets creators and small businesses

Disclosure: I'm the maintainer of LinkyPO. Happy to adjust the description or remove if it doesn't fit.