### PR TITLE
Add Beton Inspector to Data Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 ## Data Analysis
 
 - [Baremetrics](https://baremetrics.com/) - Metrics, dunning, and engagement tools for SaaS & subscription businesses.
+- [Beton Inspector](https://github.com/getbeton/inspector) - Open-source revenue intelligence; scores accounts from PostHog product-usage data + CRM and routes the warmest leads to sales. Self-hostable (OSS alternative to Pocus / Common Room).
 - [GrowingIO](https://www.growingio.com/) - 一站式数字化增长整体方案服务商。为产品、运营、市场、数据团队及管理者提供客户数据平台（CDP）、广告分析、产品分析、智能运营等产品和咨询服务。
 - [BDP](https://me.bdp.cn/home.html) - Data analysis platform.
 - [ChartCube](https://chartcube.alipay.com/) - Online chart generator.


### PR DESCRIPTION
Adding [Beton Inspector](https://github.com/getbeton/inspector) to **Data Analysis** — open-source (AGPL-3.0) revenue intelligence that scores accounts from PostHog product-usage data + CRM and routes the warmest leads to sales reps. Self-hostable. Open-source alternative to Pocus / Common Room.