### PR TITLE
feat: add NotFair — open-source Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [PagesRUs](https://pagesrus.com) - AI-powered B2B business discovery and lead generation platform to find companies, suppliers, distributors, and buyers by niche and location.
 - [SalesLabel](https://sales-label.com) - White-label outbound sales infrastructure platform for B2B agencies. Helps 100+ agencies launch reseller offers under their own brand.
 - [Shotlingo](https://shotlingo.com) - AI-powered App Store screenshot localization for 40+ languages. Translate, preview, and batch-export App Store / Google Play screenshots — text expansion, RTL mirror, and per-locale fonts handled automatically.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live account data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 
 ## Low & No Code Platform


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills for marketing work (~2.9k stars, MIT license). It covers SEO/GEO site analysis, keyword research, meta tags, schema markup, content writing, Google Ads audits, and Meta Ads performance review.

What makes it a bit different is that it connects to live account data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so the skills run against real campaign data rather than static inputs.

I've added it to the **Marketing** section to sit alongside the other digital-marketing tools there. Happy to reword, move, or trim the entry if you'd prefer something shorter or a different placement.

Thanks again!