### PR TITLE
Add AnswerLens to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 
 ## Marketing
 
+- [AnswerLens](https://app.sfdj.net/) - Finds public evidence gaps on B2B SaaS websites before marketing, sales, or launch work.
 - [WebCoreLab](https://webcorelab.com) — AI-First digital agency. SEO/GEO/AEO audits, CRO, WordPress/React builds. 13+ verified case studies. Toronto, est. 2014.
 - [灵犀](https://www.getlingxi.com/) - 快速搭建高转化落地页
 - [智趣百川](https://www.scrmtech.com/marketing.html) - 全渠道获客|线索管理与孵化|销售自动化|营销闭环体系.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 
 ## Marketing
 
-- [AnswerLens](https://app.sfdj.net/) - Finds public evidence gaps on B2B SaaS websites before marketing, sales, or launch work.
+- [AnswerLens](https://app.sfdj.net/) - Audits B2B SaaS pricing pages for plan-fit, proof, and decision-making gaps.
 - [WebCoreLab](https://webcorelab.com) — AI-First digital agency. SEO/GEO/AEO audits, CRO, WordPress/React builds. 13+ verified case studies. Toronto, est. 2014.
 - [灵犀](https://www.getlingxi.com/) - 快速搭建高转化落地页
 - [智趣百川](https://www.scrmtech.com/marketing.html) - 全渠道获客|线索管理与孵化|销售自动化|营销闭环体系.


### PR DESCRIPTION
Adds AnswerLens to the Marketing section.

AnswerLens checks B2B SaaS websites for public evidence gaps before teams invest more in marketing, sales, or launch work. I kept the entry short to match the existing list style.

Disclosure: I work on AnswerLens.