### PR TITLE
Add Hellomatik

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [Lobe](https://lobe.ai/) - Helps you train machine learning models with a free, easy to use tool.
 - [wombo.art](https://app.wombo.art/) - Create amazing works of art in seconds with the power of AI.
 - [Vedika](https://vedika.io/) - AI-powered Vedic astrology API with 6-agent swarm intelligence for natural language predictions.
+- [Hellomatik](https://hellomatik.com) - AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web.
 
 ## VR
 


### PR DESCRIPTION
Adds **Hellomatik** to the list. Hellomatik is an AI agent platform that turns a company's own knowledge into agents that answer, sell and book across WhatsApp, email and web. Single entry matched to the section format. Thanks for maintaining this!