### PR TITLE
Add Klinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [Screpy](https://screpy.com/) - AI-assisted SEO platform for technical audits, rank tracking, page-speed monitoring, and reporting.
 - [GetAppNiche](https://getappniche.com/) - iOS App Store market intelligence for revenue estimates, ASO keywords, competitor ads, reviews, and niche research.
 - [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live account data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+- [Klinky](https://klinky.io/) - A/B testing link shortener: split one link between two destinations at chosen weights and compare results with real-time click analytics. Free tier available.
 
 
 ## Low & No Code Platform


### PR DESCRIPTION
Adds [Klinky](https://klinky.io/) to the Marketing section.

Klinky is an A/B testing link shortener: one short link splits traffic between two destinations at weights you choose, with real-time click analytics to compare variants. It is a SaaS with a free tier. Entry follows the existing format of the section.
