### PR TITLE
Add Vacato — RDAP domain availability watchlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A curated list of awesome SaaS (Software as a server) starter.
 - [Sentry](https://sentry.io/welcome/) - Application monitoring platform helps every developer diagnose, fix, and optimize the performance of their code.
 - [loggly](https://www.loggly.com/) - Log analysis & monitoring in the cloud.
 - [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring dashboard for 114+ developer APIs including AWS, Stripe, GitHub, and OpenAI.
+- [Vacato](https://vacato.io) - RDAP domain availability watchlist. Free 10 domains with email/Telegram alerts when a name opens — alerts only, not a drop-catcher.
 - [Muscula](https://muscula.com/) - Lightweight, affordable, AI-powered error monitoring and debugging platform for applications and websites.
 
 ## CRM & HR


### PR DESCRIPTION
## Summary
- Adds [Vacato](https://vacato.io) under **Log Analysis** (monitoring peers)
- Free RDAP domain watchlist + email/Telegram alerts
- Honest: alerts only — not a drop-catcher
